### PR TITLE
feat: add audit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ output example:
 
 ![](doc/imgs/code_quality_security_audit_failed_example.png)
 
+#### options for security_audit:
+
+```
+# e.g.: code_quality security_audit bundler_audit_options="--ignore CVE-2015-9284"
+# options:
+#   bundler_audit_options: pass extract options, e.g.: bundler_audit_options="--ignore CVE-2015-9284 --verbose"
+```
 
 #### work with CI
 

--- a/lib/tasks/code_quality.rake
+++ b/lib/tasks/code_quality.rake
@@ -36,9 +36,11 @@ namespace :code_quality do
 
     desc "bundler audit"
     task :bundler_audit => :prepare do |task|
+      options = options_from_env(:bundler_audit_options)
+
       run_audit task, "bundler audit - checks for vulnerable versions of gems in Gemfile.lock" do
         # Update the ruby-advisory-db and check Gemfile.lock
-        report = `bundle audit check --update`
+        report = `bundle audit check --update #{options[:bundler_audit_options]}`
         @report_path = "#{report_dir}/bundler-audit-report.txt"
         File.open(@report_path, 'w') {|f| f.write report }
         puts report


### PR DESCRIPTION
It need to add --ignore option to `bundle audit check` method because some vulnerabilities like [CVE-2015-9284](https://github.com/omniauth/omniauth/pull/809) fixed by other gem but not itself.

![image](https://user-images.githubusercontent.com/846003/61842342-60aba800-aeca-11e9-8517-f294210a1ad2.png)
