### PR TITLE
fix invalid multibyte char (US-ASCII) bug

### DIFF
--- a/app/views/code_quality/index.html.erb
+++ b/app/views/code_quality/index.html.erb
@@ -8,7 +8,7 @@
 
 <ul>
 <% @audit_tasks.each do |task_name, report| %>
-  <li>[<%= report[:failure].empty? ? "✓" : "✗" %>] <a href="<%= report[:report_path] %>"><%= task_name %></a> <%= report[:failure] %></li>
+  <li>[<%= report[:failure].empty? ? "&#x2713;" : "&#x2717;" %>] <a href="<%= report[:report_path] %>"><%= task_name %></a> <%= report[:failure] %></li>
 <% end %>
 </ul>
 


### PR DESCRIPTION
steps to reproduce the bug:

```
docker run -it --rm ruby:2.5.3 bash
gem sources --add https://gems.ruby-china.com/ --remove https://rubygems.org/
gem install code_quality --no-document

cd /var/tmp
export CI=yes

code_quality quality_audit fail_fast=false generate_index=true skip_lowest_score=89 rubocop_max_offenses=400
```

output:

```
code_quality aborted!
SyntaxError: (erb):11: invalid multibyte char (US-ASCII)
(erb):11: invalid multibyte char (US-ASCII)
(erb):11: invalid multibyte char (US-ASCII)
(erb):11: invalid multibyte char (US-ASCII)
(erb):11: invalid multibyte char (US-ASCII)
(erb):11: invalid multibyte char (US-ASCII)
/usr/local/bundle/gems/code_quality-0.5.1/lib/tasks/code_quality.rake:377:in `generate_index'
/usr/local/bundle/gems/code_quality-0.5.1/lib/tasks/code_quality.rake:115:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/code_quality-0.5.1/lib/code_quality/cli.rb:23:in `block in run'
/usr/local/bundle/gems/code_quality-0.5.1/lib/code_quality/cli.rb:20:in `run'
/usr/local/bundle/gems/code_quality-0.5.1/lib/code_quality/cli.rb:6:in `start'
/usr/local/bundle/gems/code_quality-0.5.1/exe/code_quality:13:in `<top (required)>'
/usr/local/bundle/bin/code_quality:23:in `load'
/usr/local/bundle/bin/code_quality:23:in `<main>'
Tasks: TOP => quality_audit => quality_audit:default => quality_audit:run_all
(See full trace by running task with --trace)
```